### PR TITLE
photo upload bug fix

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -7,19 +7,26 @@ class PhotosController < ApplicationController
     @photo = current_user.photos.build(photo_params)
     @photo.took_date = Time.now
 
-    if @photo.save!
+    if @photo.save
       pic_path = (@photo.content).to_s
       pic_path_split = pic_path.split("/")
-      pic_name = pic_path_split.last.split("?")
+      pic_name = pic_path_split.last.split("?");''
       path_num = "%03d" % ((@photo.id).to_i)
 
       @photo.took_date = (EXIFR::JPEG.new('public/system/photos/contents/000/000/' +
                                           path_num.to_s + '/original/' + pic_name[0])).date_time_original
+      @photo.took_date ||= Time.now
 
-      if  @photo.save!
-        flash[:sucess] = "Photo uploaded"
+      if  @photo.save
+        flash[:success] = "Photo uploaded"        
+        redirect_to user_path(current_user)
+      else
+        flash[:error] = "Photo upload error"
         redirect_to user_path(current_user)
       end
+    else
+      flash[:error] = "JPG, JPEG files are only supported"
+      redirect_to user_path(current_user)
     end
   end
 

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -10,7 +10,7 @@ class PhotosController < ApplicationController
     if @photo.save
       pic_path = (@photo.content).to_s
       pic_path_split = pic_path.split("/")
-      pic_name = pic_path_split.last.split("?");''
+      pic_name = pic_path_split.last.split("?")
       path_num = "%03d" % ((@photo.id).to_i)
 
       @photo.took_date = (EXIFR::JPEG.new('public/system/photos/contents/000/000/' +


### PR DESCRIPTION
写真アップ時にEXIF情報が無いとコケる問題を解決
=> EXIF情報がない場合現在時刻をtook_timenに突っ込むようにした
EXIF情報が無い or 形式が違うファイルをアップした時ダッシュボードにリダイレクトされない問題を解決
=> リダイレクトしてそれぞれに応じたflashを出すよう修正
