### PR TITLE
postinstall file

### DIFF
--- a/postinstall
+++ b/postinstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -e
-ln -s /etc/images /home/sqale/current/public/system
+ln -s /home/sqale/etc/images /home/sqale/current/public/system

--- a/postinstall
+++ b/postinstall
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -e
+ln -s /home/sqale/current/public/system /etc/images/

--- a/postinstall
+++ b/postinstall
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -e
-ln -s /home/sqale/current/public/system /etc/images/
+ln -s /etc/images /home/sqale/current/public/system


### PR DESCRIPTION
postinstall利用のためにpostinstallファイルを追加。
デフォルトでは/public/system/photos/〜〜にアップされた画像が置かれるので、
/public/systemを/etc/imagesへのシンボリックリンクとして設置するように設定。
